### PR TITLE
Set interval due to timeout only being once!

### DIFF
--- a/src/NGIO.js
+++ b/src/NGIO.js
@@ -418,7 +418,7 @@ class NGIO
 			this.#lastConnectionStatus = this.STATUS_INITIALIZED;
 
 			// auto-ping the server every 30 seconds once connected
-			setTimeout(function() {
+			setInterval(function() {
 				NGIO.keepSessionAlive();
 			}, 30000)
 		}


### PR DESCRIPTION
In the main NGIO.js file timeout is being called, this makes the keep alive function only be called once!